### PR TITLE
Update depricated provider and k8s versions

### DIFF
--- a/crossplane-config/provider-azure.yaml
+++ b/crossplane-config/provider-azure.yaml
@@ -5,6 +5,6 @@ kind: Provider
 metadata:
   name: crossplane-provider-jet-azure
 spec:
-  package: crossplane/provider-jet-azure:v0.6.0-preview
+  package: crossplane/provider-jet-azure:v0.12.0-preview
   # controllerConfigRef:
   #   name: debug-config

--- a/packages/k8s/aks.yaml
+++ b/packages/k8s/aks.yaml
@@ -24,7 +24,7 @@ spec:
           resourceGroupName: crossplane-demo
           location: eastus
           dnsPrefix: punasusi
-          kubernetesVersion: "1.21.2"
+          kubernetesVersion: "1.23.8"
           defaultNodePool:
           - maxCount: 10
             enableAutoScaling: true


### PR DESCRIPTION
Demo cluster did not set up in Azure due to Kubernetes-version being unsupported in the given Azure-region. Changed version to a supported one.

Also, updated jet-azure-provider to newest version.